### PR TITLE
Adding option to persist component state

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -15,6 +15,8 @@ React higher order component to provide UI state for components.
 - An action gets dispatched like `UI_STATE_SET:some-component_<uuid>`
 - Component state gets removed from store on `componentWillUnmount`
 
+In the event that `persist: true` is supplied to the config options, the name of the component's key within `uiState` will match the `name` param.
+
 `setUiState`: Simple update function that accepts an object that will be shallow merged with current state. Accepts an optional callback called with the state change.
 
 `resetUiState`: Function to reset component to initial state. Accepts an optional callback called with the initial state.
@@ -64,6 +66,7 @@ export function someComponent ({
 
 const uiStateConfig = {
     name: 'some-component',
+    persist: true, // optional
     state: (props) => ({
         someUiFlag: false,
         somePassedThing: props.x ? props.x : null;

--- a/README.MD
+++ b/README.MD
@@ -15,15 +15,49 @@ React higher order component to provide UI state for components.
 - An action gets dispatched like `UI_STATE_SET:some-component_<uuid>`
 - Component state gets removed from store on `componentWillUnmount`
 
-In the event that `persist: true` is supplied to the config options, the name of the component's key within `uiState` will match the `name` param.
-
 `setUiState`: Simple update function that accepts an object that will be shallow merged with current state. Accepts an optional callback called with the state change.
 
 `resetUiState`: Function to reset component to initial state. Accepts an optional callback called with the initial state.
 
-Simple to use:
+## uiState Options
 
-```javascript
+#### `name {String | Function}`
+If a string is provided a uuid will be suffixed in order not to overwrite the state in the store. Providing a function gives you the ability to create your own unique name, with the ability to use the component's `props`, e.g:
+
+```js
+const uiStateConfig = {
+    ...
+    name: props => `MyComponent__${props.className}`,
+    ...
+};
+```
+
+#### `state {Function}`
+Extend the wrapper component's props, e.g.
+```js
+const uiStateConfig = {
+    ...
+    state: (props) => ({
+        myProp: 'myProp'
+    }),
+    ...
+};
+```
+
+#### `persist {Boolean}`
+Defaults to `false`. If `true` the component's state will not be removed from the `uiState` domain.
+
+```js
+const uiStateConfig = {
+    persist: true,
+    ...
+};
+```
+
+
+## Usage:
+
+```jsx
 // rootReducer.js
 import { combineReducers } from 'redux';
 import { uiStateReducer } from 'react-redux-ui-state';

--- a/dist/hoc.js
+++ b/dist/hoc.js
@@ -38,8 +38,9 @@ exports.default = function (config) {
 
                 var _this = _possibleConstructorReturn(this, (uiState.__proto__ || Object.getPrototypeOf(uiState)).call(this, props));
 
-                _this.uiStateName = (0, _.generateName)(config.name);
+                _this.uiStateName = config.persist ? config.name : (0, _.generateName)(config.name);
                 _this.initState = config.state(_this.props);
+                _this.config = config;
                 return _this;
             }
 
@@ -51,7 +52,9 @@ exports.default = function (config) {
             }, {
                 key: 'componentWillUnmount',
                 value: function componentWillUnmount() {
-                    this.props.delete(this.uiStateName);
+                    if (!this.config.persist) {
+                        this.props.delete(this.uiStateName);
+                    }
                 }
             }, {
                 key: 'render',

--- a/dist/hoc.js
+++ b/dist/hoc.js
@@ -38,7 +38,7 @@ exports.default = function (config) {
 
                 var _this = _possibleConstructorReturn(this, (uiState.__proto__ || Object.getPrototypeOf(uiState)).call(this, props));
 
-                _this.uiStateName = config.persist ? config.name : (0, _.generateName)(config.name);
+                _this.uiStateName = typeof config.name === 'function' ? config.name(props) : (0, _.generateName)(config.name);
                 _this.initState = config.state(_this.props);
                 _this.config = config;
                 return _this;

--- a/src/hoc.js
+++ b/src/hoc.js
@@ -13,8 +13,9 @@ export default config => WrappedComponent => {
     class uiState extends Component {
         constructor(props) {
             super(props);
-            this.uiStateName = generateName(config.name);
+            this.uiStateName = config.persist ? config.name : generateName(config.name);
             this.initState = config.state(this.props);
+            this.config = config;
         }
 
         componentWillMount() {
@@ -22,7 +23,9 @@ export default config => WrappedComponent => {
         }
 
         componentWillUnmount() {
-            this.props.delete(this.uiStateName);
+            if (!this.config.persist) {
+                this.props.delete(this.uiStateName);
+            }
         }
 
         render() {

--- a/src/hoc.js
+++ b/src/hoc.js
@@ -13,7 +13,9 @@ export default config => WrappedComponent => {
     class uiState extends Component {
         constructor(props) {
             super(props);
-            this.uiStateName = config.persist ? config.name : generateName(config.name);
+            this.uiStateName = (typeof config.name === 'function')
+                ? config.name(props)
+                : generateName(config.name);
             this.initState = config.state(this.props);
             this.config = config;
         }


### PR DESCRIPTION
If the config option of `persist` is added the key for the uiState
domain will match the `name` option and no uuid will be added as
a suffix. Similarly, the component's state will not be removed from the
store when the component unmounts.