### PR TITLE
Add sub-state equality check before rendering component

### DIFF
--- a/dist/hoc.js
+++ b/dist/hoc.js
@@ -16,6 +16,10 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _isEqual = require('lodash/isEqual');
+
+var _isEqual2 = _interopRequireDefault(_isEqual);
+
 var _reactRedux = require('react-redux');
 
 var _ = require('./');
@@ -48,6 +52,13 @@ exports.default = function (config) {
                 key: 'componentWillMount',
                 value: function componentWillMount() {
                     this.props.add(this.initState, this.uiStateName);
+                }
+            }, {
+                key: 'shouldComponentUpdate',
+                value: function shouldComponentUpdate(nextProps) {
+                    var currentState = this.props.uiState[this.uiStateName];
+                    var nextState = nextProps.uiState[this.uiStateName];
+                    return !(0, _isEqual2.default)(currentState, nextState);
                 }
             }, {
                 key: 'componentWillUnmount',

--- a/src/hoc.js
+++ b/src/hoc.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
 import { connect } from 'react-redux';
 import {
     dispatchToProps,
@@ -22,6 +23,12 @@ export default config => WrappedComponent => {
 
         componentWillMount() {
             this.props.add(this.initState, this.uiStateName);
+        }
+
+        shouldComponentUpdate(nextProps) {
+            const currentState = this.props.uiState[this.uiStateName];
+            const nextState = nextProps.uiState[this.uiStateName];
+            return !isEqual(currentState, nextState);
         }
 
         componentWillUnmount() {


### PR DESCRIPTION
Prevents unnecessary rendering of separate uiState-wrapped components