### PR TITLE
Add check for persistent uiState on mount

### DIFF
--- a/dist/hoc.js
+++ b/dist/hoc.js
@@ -47,7 +47,9 @@ exports.default = function (config) {
             _createClass(uiState, [{
                 key: 'componentWillMount',
                 value: function componentWillMount() {
-                    this.props.add(this.initState, this.uiStateName);
+                    if (!this.config.persist || !this.props.uiState[this.uiStateName]) {
+                        this.props.add(this.initState, this.uiStateName);
+                    }
                 }
             }, {
                 key: 'componentWillUnmount',

--- a/src/hoc.js
+++ b/src/hoc.js
@@ -21,7 +21,9 @@ export default config => WrappedComponent => {
         }
 
         componentWillMount() {
-            this.props.add(this.initState, this.uiStateName);
+            if (!this.config.persist || !this.props.uiState[this.uiStateName]) {
+                this.props.add(this.initState, this.uiStateName);
+            }
         }
 
         componentWillUnmount() {


### PR DESCRIPTION
This PR corrects some irregular behavior with the persist flag when the component mounts.

New state should only be added to the store on mount if:
a) persist flag is not set or
b) persist flag is set AND uiState does not already exist in the store